### PR TITLE
Fix: missing padding on Navbar

### DIFF
--- a/components/layout/navbar/navbar.tsx
+++ b/components/layout/navbar/navbar.tsx
@@ -74,6 +74,7 @@ const Navbar = () => {
           width: 100%;
           display: flex;
           justify-content: space-between;
+          padding: 0 25px;
         }
 
         .navbar__btn {


### PR DESCRIPTION
Before:
![beforenav](https://user-images.githubusercontent.com/36450233/119526668-42de5100-bd88-11eb-8e22-646e8012eeea.png)

After:
![afternav](https://user-images.githubusercontent.com/36450233/119526685-44a81480-bd88-11eb-94f5-5e9c9daa6ffb.png)

